### PR TITLE
Social links in theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# clone of theme we're etending
+mkdocs-material
+
 #### joe made this: http://goel.io/joe
 
 #### python ####

--- a/.trufflehog.txt
+++ b/.trufflehog.txt
@@ -1,1 +1,2 @@
 .*gitleaks.toml$
+.*mkdocs_theme.yml$

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,15 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.1.0](https://github.com/ASFHyP3/asf-mkdocs-theme/compare/v0.0.0...develop)
+
+### Added
+- Social links to the footer
+
+### Changed
+- Added search functionality uses the `search.html` partial instead of being directly
+  inserted into the header
+
+## [0.1.0](https://github.com/ASFHyP3/asf-mkdocs-theme/compare/v0.0.0...develop)
+
 ### Added
 - MkDocs theme based on material to match ASF branding

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0](https://github.com/ASFHyP3/asf-mkdocs-theme/compare/v0.0.0...develop)
+## [0.2.0](https://github.com/ASFHyP3/asf-mkdocs-theme/compare/v0.1.0...v0.2.0)
 
 ### Added
 - Social links to the footer
@@ -15,7 +15,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Added search functionality uses the `search.html` partial instead of being directly
   inserted into the header
 
-## [0.1.0](https://github.com/ASFHyP3/asf-mkdocs-theme/compare/v0.0.0...develop)
+## [0.1.0](https://github.com/ASFHyP3/asf-mkdocs-theme/compare/v0.0.0...v0.1.0)
 
 ### Added
 - MkDocs theme based on material to match ASF branding

--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
 # ASF MkDocs Theme
 
 An extension of the MkDocs Material Theme for ASF
+
+## Social links
+
+You can add *additional* social links by with
+```yaml
+extra:
+social:
+  - icon: fontawesome/brands/gitter
+    link: https://gitter.im/ASFHyP3/community
+```
+ 
+You can *Override* the theme provided social with
+```yaml
+theme:
+social:
+  - icon: fontawesome/brands/gitter
+    link: https://gitter.im/ASFHyP3/community
+```
+] 

--- a/README.md
+++ b/README.md
@@ -20,4 +20,3 @@ theme:
     - icon: fontawesome/brands/gitter
       link: https://gitter.im/ASFHyP3/community
 ```
-] 

--- a/README.md
+++ b/README.md
@@ -4,19 +4,20 @@ An extension of the MkDocs Material Theme for ASF
 
 ## Social links
 
-You can add *additional* social links by with
+You can add *additional* social links with
 ```yaml
 extra:
-social:
-  - icon: fontawesome/brands/gitter
-    link: https://gitter.im/ASFHyP3/community
+  social:
+    - icon: fontawesome/brands/gitter
+      link: https://gitter.im/ASFHyP3/community
 ```
  
-You can *Override* the theme provided social with
+You can *Override* the theme provided social link with
 ```yaml
 theme:
-social:
-  - icon: fontawesome/brands/gitter
-    link: https://gitter.im/ASFHyP3/community
+  name: "asf-theme"
+  social:
+    - icon: fontawesome/brands/gitter
+      link: https://gitter.im/ASFHyP3/community
 ```
 ] 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ extra:
       link: https://gitter.im/ASFHyP3/community
 ```
  
-You can *Override* the theme provided social link with
+You can *Override* the theme provided social links with
 ```yaml
 theme:
   name: "asf-theme"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ extra:
       link: https://gitter.im/ASFHyP3/community
 ```
  
-You can *Override* the theme provided social links with
+You can *override* the theme provided social links with
 ```yaml
 theme:
   name: "asf-theme"

--- a/asf_theme/mkdocs_theme.yml
+++ b/asf_theme/mkdocs_theme.yml
@@ -7,3 +7,12 @@ favicon: assets/images/favicon.ico
 
 # ASF's Logo
 logo: assets/images/ASFLogo-Blue2.png
+
+# ASF's social links
+social:
+  - icon: fontawesome/brands/facebook-f
+    link: https://www.facebook.com/AKSatellite
+  - icon: fontawesome/brands/twitter
+    link: https://twitter.com/Ak_Satellite
+  - icon: fontawesome/brands/youtube
+    link: https://www.youtube.com/channel/UChCfI0oVWw4qDwEidnDskJQ

--- a/asf_theme/partials/footer.html
+++ b/asf_theme/partials/footer.html
@@ -1,11 +1,39 @@
-{#-
-  This file was automatically generated - do not edit
--#}
+<!--
+  Copyright (c) 2016-2020 Martin Donath <martin.donath@squidfunk.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to
+  deal in the Software without restriction, including without limitation the
+  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+  sell copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+-->
+
 {% import "partials/language.html" as lang with context %}
+
+<!-- Application footer -->
 <footer class="md-footer">
+
+  <!-- Link to previous and/or next page -->
   {% if page.previous_page or page.next_page %}
     <div class="md-footer-nav">
-      <nav class="md-footer-nav__inner md-grid" aria-label="{{ lang.t('footer.title') }}">
+      <nav
+        class="md-footer-nav__inner md-grid"
+        aria-label="{{ lang.t('footer.title') }}"
+      >
+
+        <!-- Link to previous page -->
         {% if page.previous_page %}
           <a href="{{ page.previous_page.url | url }}" class="md-footer-nav__link md-footer-nav__link--prev" rel="prev">
             <div class="md-footer-nav__button md-icon">
@@ -21,6 +49,8 @@
             </div>
           </a>
         {% endif %}
+
+        <!-- Link to next page -->
         {% if page.next_page %}
           <a href="{{ page.next_page.url | url }}" class="md-footer-nav__link md-footer-nav__link--next" rel="next">
             <div class="md-footer-nav__title">
@@ -37,6 +67,8 @@
           </a>
         {% endif %}
       </nav>
+
+      <!-- ASF Footer information-->
       <div class="md-grid">
         <div class="md-footer-container md-grid">
           <div class="md-footer-container-item">
@@ -74,12 +106,18 @@
       </div>
     </div>
   {% endif %}
+
+  <!-- Further information -->
   <div class="md-footer-meta md-typeset">
     <div class="md-footer-meta__inner md-grid">
+
+      <!-- Copyright and theme information -->
       <div class="md-footer-copyright">
         {% if config.copyright %}
           <div class="md-footer-copyright__highlight">
             {{ config.copyright }}
+
+            <!-- ASF non-discrimination disclaimer-->
             &nbsp;&nbsp;
             <a href="https://www.alaska.edu/nondiscrimination"
                target="_blank"
@@ -90,6 +128,8 @@
           </div>
         {% endif %}
       </div>
+
+      <!-- Social links -->
       {% include "partials/social.html" %}
     </div>
   </div>

--- a/asf_theme/partials/header.html
+++ b/asf_theme/partials/header.html
@@ -69,11 +69,9 @@
       {% endif %}
     </div>
 
-    <!-- Button to open search dialogue -->
     {% if "search" in config["plugins"] %}
-      <div class="expert-rec-search">
-        <ci-search></ci-search>
-      </div>
+     <!-- Search interface -->
+      {% include "partials/search.html" %}
     {% endif %}
 
     <!-- Repository containing source -->

--- a/asf_theme/partials/search.html
+++ b/asf_theme/partials/search.html
@@ -1,0 +1,3 @@
+<div class="expert-rec-search">
+  <ci-search></ci-search>
+</div>

--- a/asf_theme/partials/social.html
+++ b/asf_theme/partials/social.html
@@ -1,0 +1,52 @@
+<!--
+  Copyright (c) 2016-2020 Martin Donath <martin.donath@squidfunk.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to
+  deal in the Software without restriction, including without limitation the
+  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+  sell copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+-->
+
+<!-- Social links in footer -->
+<div class="md-footer-social">
+    {% for social in config.theme.social %}
+      {% set title = social.name %}
+      {% if not title and "//" in social.link %}
+        {% set _,url = social.link.split("//") %}
+        {% set title = url.split("/")[0] %}
+      {% endif %}
+      <a href="{{ social.link }}" target="_blank" rel="noopener" title="{{ title | e }}" class="md-footer-social__link">
+        {% include ".icons/" ~ social.icon ~ ".svg" %}
+      </a>
+    {% endfor %}
+    {% if config.extra.social %}
+        {% for social in config.extra.social %}
+          {% set title = social.name %}
+          {% if not title and "//" in social.link %}
+            {% set _,url = social.link.split("//") %}
+            {% set title = url.split("/")[0] %}
+          {% endif %}
+          <a
+            href="{{ social.link }}"
+            target="_blank" rel="noopener"
+            title="{{ title | e }}"
+            class="md-footer-social__link"
+          >
+            {% include ".icons/" ~ social.icon ~ ".svg" %}
+          </a>
+        {% endfor %}
+    {% endif %}
+</div>


### PR DESCRIPTION
This add the ASF social links to the footer by default. 

Downstream docs sites can:
* Add *additional* social links by adding
  ```yaml
  extra:
    social:
      - icon: fontawesome/brands/gitter
        link: https://gitter.im/ASFHyP3/community
  ```
  To their `mkdocs.yml`
  
* **Override** these social links by adding
  ```yaml
  theme:
    social:
      - icon: fontawesome/brands/gitter
        link: https://gitter.im/ASFHyP3/community
  ```
  To their `mkdocs.yml`
 
fixes #4
