### PR TITLE
ASF and Site logos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 - Added search functionality uses the `search.html` partial instead of being directly
   inserted into the header
+- Now includes two logos for a site - the ASF logo (linking back to ASF), and the
+  site logo (linking back to the site home page)
 
 ## [0.1.0](https://github.com/ASFHyP3/asf-mkdocs-theme/compare/v0.0.0...v0.1.0)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,57 @@
 # ASF MkDocs Theme
 
-An extension of the MkDocs Material Theme for ASF
+An extension of the MkDocs Material Theme for ASF.
+
+## Logos
+
+By default, this theme will provide both the ASF logo and a site logo.
+
+### ASF logo
+
+You can change the ASF logo with
+```yaml
+theme:
+  name: "asf-theme"
+  asf_logo: images/asf-altenate-logo.png
+```
+
+or remove the ASF logo with
+```yaml
+theme:
+  name: "asf-theme"
+  asf_logo:
+```
+
+
+
+### Site logo
+With the Material Theme, there are
+[two ways to change the site logo](https://squidfunk.github.io/mkdocs-material/setup/changing-the-logo-and-icons/#logo).
+
+1. You can change site logo with a direct link to an image
+   ```yaml
+   theme:
+     name: "asf-theme"
+     logo: images/my-logo.png
+   ```
+
+2. or by specifying an icon
+   ```yaml
+   theme:
+     name: "asf-theme"
+     icon:
+       logo: material/library
+   ```
+
+
+To remove the site logo, specify an empty icon (and no theme logo)
+```yaml
+theme:
+  name: "asf-theme"
+  icon:
+    logo:
+```
+
 
 ## Social links
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ASF MkDocs Theme
 
-An extension of the MkDocs Material Theme for ASF.
+An extension of the [MkDocs Material Theme](https://squidfunk.github.io/mkdocs-material/)
+for ASF.
 
 ## Logos
 
@@ -21,8 +22,6 @@ theme:
   name: "asf-theme"
   asf_logo:
 ```
-
-
 
 ### Site logo
 With the Material Theme, there are

--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ By default, this theme will provide both the ASF logo and a site logo.
 
 ### ASF logo
 
-You can change the ASF logo with
+You can change the ASF logo and/or logo URL with
 ```yaml
 theme:
   name: "asf-theme"
   asf_logo: images/asf-altenate-logo.png
+  asf_logo_url: https://asf.alaska.edu/
 ```
 
 or remove the ASF logo with

--- a/asf_theme/assets/stylesheets/asf.css
+++ b/asf_theme/assets/stylesheets/asf.css
@@ -19,8 +19,8 @@ a {
 }
 
 .md-header-nav__button.md-logo img {
-  width: 3.2rem;
-  height: auto;
+  height: 2.0rem;
+  width: auto;
   display: inline-block;
   margin-top: -7px;
 }

--- a/asf_theme/mkdocs_theme.yml
+++ b/asf_theme/mkdocs_theme.yml
@@ -2,6 +2,10 @@
 #   https://github.com/squidfunk/mkdocs-material
 extends: material
 
+# Default site logo
+icon:
+  logo: material/library
+
 # Favicon to be rendered
 favicon: assets/images/favicon.ico
 

--- a/asf_theme/mkdocs_theme.yml
+++ b/asf_theme/mkdocs_theme.yml
@@ -11,6 +11,7 @@ favicon: assets/images/favicon.ico
 
 # ASF's Logo
 asf_logo: assets/images/ASFLogo-Blue2.png
+asf_logo_url: https://asf.alaska.edu/
 
 # ASF's social links
 social:

--- a/asf_theme/mkdocs_theme.yml
+++ b/asf_theme/mkdocs_theme.yml
@@ -6,7 +6,7 @@ extends: material
 favicon: assets/images/favicon.ico
 
 # ASF's Logo
-logo: assets/images/ASFLogo-Blue2.png
+asf_logo: assets/images/ASFLogo-Blue2.png
 
 # ASF's social links
 social:

--- a/asf_theme/partials/header.html
+++ b/asf_theme/partials/header.html
@@ -35,7 +35,7 @@
     {% if config.theme.asf_logo %}
       <!-- Link to ASF -->
       <a
-        href="https://asf.alaska.edu/"
+        href="{{ config.theme.asf_logo_url }}"
         title="ASF"
         class="md-header-nav__button md-logo"
         aria-label="ASF"

--- a/asf_theme/partials/header.html
+++ b/asf_theme/partials/header.html
@@ -32,6 +32,16 @@
   <!-- Top-level navigation -->
   <nav class="md-header-nav md-grid" aria-label="{{ lang.t('header.title') }}">
 
+    {% if config.theme.asf_logo %}
+      <!-- Link to ASF -->
+      <a
+        href="https://asf.alaska.edu/"
+        title="ASF"
+        class="md-header-nav__button md-logo"
+        aria-label="ASF"
+      >
+      <img src="{{ config.theme.asf_logo | url }}" alt="logo" />
+    {% endif %}
     <!-- Link to home -->
     <a
       href="{{ site_url }}"

--- a/asf_theme/partials/logo.html
+++ b/asf_theme/partials/logo.html
@@ -1,0 +1,28 @@
+<!--
+  Copyright (c) 2016-2020 Martin Donath <martin.donath@squidfunk.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to
+  deal in the Software without restriction, including without limitation the
+  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+  sell copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+-->
+
+<!-- Logo -->
+{% if config.theme.logo %}
+  <img src="{{ config.theme.logo | url }}" alt="logo" />
+{% elif config.theme.icon.logo %}
+  {% include ".icons/" ~ config.theme.icon.logo ~ ".svg" %}
+{% endif %}


### PR DESCRIPTION
Adds an ASF logo to the theme which will link back to the ASF main site:
![image](https://user-images.githubusercontent.com/7882693/102677029-de6df480-414c-11eb-99f1-4f302a65fc75.png)

By default, both logos are provided, but either/both can also be removed (see `README.md` for usage).

fixes #5 