### PR TITLE
avoid implicit call to document.clear()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1](https://github.com/ASFHyP3/asf-mkdocs-theme/compare/v0.2.0...v0.2.1)
+### Changed
+- HTML in partials footer no longer calls document.write() should fix bug where page gets deleted and replaced by current year
+
 ## [0.2.0](https://github.com/ASFHyP3/asf-mkdocs-theme/compare/v0.1.0...v0.2.0)
 
 ### Added

--- a/asf_theme/partials/footer.html
+++ b/asf_theme/partials/footer.html
@@ -117,8 +117,8 @@
           {% if config.copyright or config.theme.copyright %}
             &copy; <span id="date"><span>
             <script type="text/javascript">
-                d = new Date().getFullYear();
-                document.getElementById(date).innerHTML=d;
+                current_year = new Date().getFullYear();
+                document.getElementById("date").innerHTML=current_year;
             </script>
             {{ config.copyright if config.copyright else config.theme.copyright}}
           {% endif %}

--- a/asf_theme/partials/footer.html
+++ b/asf_theme/partials/footer.html
@@ -115,10 +115,10 @@
       <div class="md-footer-copyright">
         <div class="md-footer-copyright__highlight">
           {% if config.copyright or config.theme.copyright %}
-            &copy; <span id="copyright-date"><span>
+            &copy; <span id="copyright-year"><span>
             <script type="text/javascript">
                 current_year = new Date().getFullYear();
-                document.getElementById("copyright-date").innerHTML=current_year;
+                document.getElementById("copyright-year").innerHTML=current_year;
             </script>
             {{ config.copyright if config.copyright else config.theme.copyright}}
           {% endif %}

--- a/asf_theme/partials/footer.html
+++ b/asf_theme/partials/footer.html
@@ -115,8 +115,10 @@
       <div class="md-footer-copyright">
         <div class="md-footer-copyright__highlight">
           {% if config.copyright or config.theme.copyright %}
-            &copy; <script type="text/javascript">
-                document.write(new Date().getFullYear());
+            &copy; <span id="date"><span>
+            <script type="text/javascript">
+                d = new Date().getFullYear();
+                document.getElementById(date).innerHTML=d;
             </script>
             {{ config.copyright if config.copyright else config.theme.copyright}}
           {% endif %}

--- a/asf_theme/partials/footer.html
+++ b/asf_theme/partials/footer.html
@@ -115,10 +115,10 @@
       <div class="md-footer-copyright">
         <div class="md-footer-copyright__highlight">
           {% if config.copyright or config.theme.copyright %}
-            &copy; <span id="date"><span>
+            &copy; <span id="copyright-date"><span>
             <script type="text/javascript">
                 current_year = new Date().getFullYear();
-                document.getElementById("date").innerHTML=current_year;
+                document.getElementById("copyright-date").innerHTML=current_year;
             </script>
             {{ config.copyright if config.copyright else config.theme.copyright}}
           {% endif %}


### PR DESCRIPTION
document.write() calls document.open() which has a chance (if the document is closed) to call document.clear() which will delete the entire page, this fixes it by dynamically adding content to a blank element without calling document.open()

<!--
If this is a pull request for a new release, please use the release template:
   https://github.com/ASFHyP3/asf-mkdocs-theme/compare/main...develop?template=release.md
 
NOTE: Pull requests should only be opened for merges to protected branches (required) and any 
changes which you'd like reviewed. Do not open a pull request to update a feature or personal
branch -- simply merge with `git`.
-->