### PR TITLE
pin material theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2](https://github.com/ASFHyP3/mkdocs-asf-theme/compare/v0.2.1...v0.2.2)
+
+### Changed
+- MkDocs Material theme 7 breaks the theme header, so the dependency is now pinned to `mkdocs-material>=6.0,<7.0`
+
 ## [0.2.1](https://github.com/ASFHyP3/mkdocs-asf-theme/compare/v0.2.0...v0.2.1)
+
 ### Changed
 - HTML in partials footer no longer calls document.write() should fix bug where page gets deleted and replaced by current year
 - Renamed github repository to `mkdocs-asf-theme` to mirror PyPI

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
 
     install_requires=[
         'mkdocs',
-        'mkdocs-material',
+        'mkdocs-material>=6.0,<7.0',
     ],
 
     packages=find_packages(),


### PR DESCRIPTION
`mkdocs-material>=7.0`  will cause the header to look like:
![image](https://user-images.githubusercontent.com/7882693/109336419-d4810580-780f-11eb-8391-d9f7281ca69c.png)

This pins to `mkdocs-material~=6`