### PR TITLE
Verify packaging needs checkout

### DIFF
--- a/.github/workflows/tag-and-distribute.yml
+++ b/.github/workflows/tag-and-distribute.yml
@@ -90,6 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: package
     steps:
+      - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
           python-version: 3.8


### PR DESCRIPTION
Last release our verify packaging test failed: https://github.com/ASFHyP3/mkdocs-asf-theme/runs/2033737425?check_suite_focus=true

For whatever reason, in order to get outputs between jobs in github actions, the checkout action needs to be run, as we're doing in the SDK:
https://github.com/ASFHyP3/hyp3-sdk/blob/develop/.github/workflows/test-and-build.yml#L142

*Note: this is completely undocumented behavior.*
