### PR TITLE
Fix footer map for project sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3](https://github.com/ASFHyP3/mkdocs-asf-theme/compare/v0.2.2...v0.2.3)
+
+### Fixed
+- ASF logo and background map now appear correctly in "Project" or repo level sites.
+
+
 ## [0.2.2](https://github.com/ASFHyP3/mkdocs-asf-theme/compare/v0.2.1...v0.2.2)
 
 ### Changed

--- a/asf_theme/assets/stylesheets/asf.css
+++ b/asf_theme/assets/stylesheets/asf.css
@@ -26,7 +26,7 @@ a {
 }
 
 .md-footer-nav {
-  background-image: url("/assets/images/map.png");
+  background-image: url("../images/map.png");
   background-repeat: no-repeat;
   background-size: cover;
   background-position: center center;

--- a/asf_theme/partials/footer.html
+++ b/asf_theme/partials/footer.html
@@ -72,7 +72,7 @@
       <div class="md-grid">
         <div class="md-footer-container md-grid">
           <div class="md-footer-container-item">
-            <img src="assets/images/asf-logo-blue-nav.png"
+            <img src="{{ 'assets/images/asf-logo-blue-nav.png' | url }}"
                  alt="ASF Logo"
                  class="md-footer-logo">
           </div>


### PR DESCRIPTION
"Project" or repo sites on GitHub pages are hosted at `[SITE]/[REPO_NAME]` instead of at the site level -- see:
https://asfadmin.github.io/asf-data-search-manual/

This fixes the map link to be relative to the  style page, and you can see the fix here:
https://jhkennedy.org/hyp3-docs/

It also fixes the logo URL to be relative to the main site via jinja templating.

Note: the ASF logo was patially fixed in #30, but was broken on sub-pages.