### PR TITLE
Fix mkdocs-material version pinning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.2.4](https://github.com/ASFHyP3/mkdocs-asf-theme/compare/v0.2.3...v0.2.4)
+
+### Fixed
+- MkDocs Material theme 6.2.0 breaks site generation, so the dependency is now pinned to `mkdocs-material>=6.2.1,<7.0`
+
 ## [0.2.3](https://github.com/ASFHyP3/mkdocs-asf-theme/compare/v0.2.2...v0.2.3)
 
 ### Fixed
-- ASF logo and background map now appear correctly in "Project" or repo level sites.
+- ASF logo and background map now appear correctly in "Project" or repo level sites
 
 
 ## [0.2.2](https://github.com/ASFHyP3/mkdocs-asf-theme/compare/v0.2.1...v0.2.2)

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
 
     install_requires=[
         'mkdocs',
-        'mkdocs-material>=6.0,<7.0',
+        'mkdocs-material>=6.2.1,<7.0',
     ],
 
     packages=find_packages(),


### PR DESCRIPTION
@Jlrine2 was having issues building a a new mkdocs website using this theme and it looks like v6.2.0 is broken for that theme, with fixes in v6.2.1. This updates the bottom pin to require 6.2.1 or greater. 

@Jlrine2 can you confirm updating that pin solves your issue?