### PR TITLE
Drop Support for Python 3.8 and 3.9

### DIFF
--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   call-version-info-workflow:
     uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.11.1
+    with:
+      python_version: "3.10"
 
   distribute:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0]
+
+### Removed
+* Dropped support for Python 3.8 and 3.9. The new minimum version is 3.10.
 
 ## [0.3.2]
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ for ASF.
 
 ## Quickstart
 
-This theme is distributed on [PyPI](https://pypi.org/project/mkdocs-asf-theme/) and can be installed into a Python 3.8+ environment using `pip`:
+This theme is distributed on [PyPI](https://pypi.org/project/mkdocs-asf-theme/) and can be installed into a Python 3.10+ environment using `pip`:
 ```
 python -m pip install mkdocs-asf-theme
 ```

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python=3.9
+  - python>=3.10
   - pip
   # For packaging and distribution
   - build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mkdocs-asf-theme"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 authors = [
     {name="ASF APD/Tools Team", email="uaf-asf-apd@alaska.edu"},
 ]
@@ -17,9 +17,8 @@ classifiers=[
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
     "mkdocs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers=[
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
     "mkdocs",


### PR DESCRIPTION
The minimum Python version is now 3.10.